### PR TITLE
Fix/provider naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Openstack Cinder and Swift plugin for [velero](https://github.com/vmware-tanzu/velero/) backups.
 
+## Table of Contents
+
+- [Velero Plugin for Openstack](#velero-plugin-for-openstack)
+  - [Compatibility](#compatibility)
+  - [Configuration](#configuration)
+    - [Install Using Velero CLI](#install-using-velero-cli)
+    - [Install Using Helm Chart](#install-using-helm-chart)
+  - [Volume Backups](#volume-backups)
+  - [Build](#build)
+  - [Test](#test)
+  - [Development](#development)
+
 ## Compatibility
 
 Below is a listing of plugin versions and respective Velero versions for which the compatibility is tested and guaranteed.

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ Initialize velero plugin
 ```bash
 # Initialize velero from scratch:
 velero install \
-       --provider "velero.io/openstack" \
-       --plugins lirt/velero-plugin-for-openstack:v0.2.0 \
+       --provider "openstack" \
+       --plugins lirt/velero-plugin-for-openstack:v0.2.1 \
        --bucket <BUCKET_NAME> \
        --no-secret
 
 # Or add plugin to existing velero:
-velero plugin add lirt/velero-plugin-for-openstack:v0.2.0
+velero plugin add lirt/velero-plugin-for-openstack:v0.2.1
 ```
 
 Change configuration of `backupstoragelocations.velero.io`:
@@ -60,14 +60,14 @@ Change configuration of `backupstoragelocations.velero.io`:
  spec:
    objectStorage:
      bucket: <BUCKET_NAME>
-   provider: velero.io/openstack
+   provider: openstack
 ```
 
 Change configuration of `volumesnapshotlocations.velero.io`:
 
 ```yaml
  spec:
-   provider: velero.io/openstack
+   provider: openstack
 ```
 
 ### Install Using Helm Chart
@@ -88,7 +88,7 @@ configuration:
     bucket: my-swift-bucket
 initContainers:
 - name: velero-plugin-openstack
-  image: lirt/velero-plugin-for-openstack:v0.2.0
+  image: lirt/velero-plugin-for-openstack:v0.2.1
   imagePullPolicy: IfNotPresent
   volumeMounts:
     - mountPath: /target

--- a/README.md
+++ b/README.md
@@ -18,13 +18,10 @@ Openstack Cinder and Swift plugin for [velero](https://github.com/vmware-tanzu/v
 
 Below is a listing of plugin versions and respective Velero versions for which the compatibility is tested and guaranteed.
 
------------------------------------
 | Plugin Version | Velero Version |
------------------------------------
+| :------------- | :------------- |
 | v0.2.x         | v1.4.x, v1.5.x |
------------------------------------
 | v0.1.x         | v1.4.x, v1.5.x |
------------------------------------
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Openstack Cinder and Swift plugin for [velero](https://github.com/vmware-tanzu/velero/) backups.
 
+## Compatibility
+
+Below is a listing of plugin versions and respective Velero versions for which the compatibility is tested and guaranteed.
+
+-----------------------------------
+| Plugin Version | Velero Version |
+-----------------------------------
+| v0.2.x         | v1.4.x, v1.5.x |
+-----------------------------------
+| v0.1.x         | v1.4.x, v1.5.x |
+-----------------------------------
+
 ## Configuration
 
 Configure velero container with your Openstack authentication environment variables:

--- a/main.go
+++ b/main.go
@@ -9,8 +9,8 @@ import (
 
 func main() {
 	veleroplugin.NewServer().
-		RegisterObjectStore("velero.io/openstack", newSwiftObjectStore).
-		RegisterVolumeSnapshotter("velero.io/openstack", newCinderBlockStore).
+		RegisterObjectStore("openstack", newSwiftObjectStore).
+		RegisterVolumeSnapshotter("openstack", newCinderBlockStore).
 		Serve()
 }
 


### PR DESCRIPTION
According to velero documentation [Plugin Naming](https://velero.io/docs/v1.5/custom-plugins/) the `velero.io/` prefix is reserved for official velero supported plugins. Remove plugin prefix.

Also update documentation ToC and missing compatiblity matrix.