### PR TITLE
fix: use proper platform when building 2nd stage docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,11 @@
+ARG GOOS=linux
+ARG GOARCH=amd64
+
 # --- First stage
 FROM golang:1.16-alpine AS build
 
 ARG REPOSITORY=Lirt
 ARG PLUGIN=velero-plugin-swift
-ARG GOOS=linux
-ARG GOARCH=amd64
 
 ENV GOPROXY=https://proxy.golang.org
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN export GOOS=${GOOS}; \
       .
 
 # --- Second stage
-FROM alpine:3
+FROM --platform=${GOOS}/${GOARCH} alpine:3
 RUN mkdir /plugins
 COPY --from=build /go/bin/${PLUGIN} /plugins/
 USER nobody:nogroup


### PR DESCRIPTION
A follow-up of #30 which permits to effectively use the `arm` or `arm64` images