### PR TITLE
Draft: Support for multiple BSLs/Clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Below is a matrix of plugin versions and Velero versions for which the compatibi
 
 | Plugin Version | Velero Version |
 | :------------- | :------------- |
-| v0.3.x         | v1.4.x, v1.5.x, v1.6.x, v1.7.x, v1.8.x |
+| v0.4.x         | v1.4.x, v1.5.x, v1.6.x, v1.7.x, v1.8.x, 1.9.x |
+| v0.3.x         | v1.4.x, v1.5.x, v1.6.x, v1.7.x, v1.8.x, 1.9.x |
 | v0.2.x         | v1.4.x, v1.5.x |
 | v0.1.x         | v1.4.x, v1.5.x |
 
@@ -127,15 +128,15 @@ Initialize velero plugin:
 # Initialize velero from scratch:
 velero install \
        --provider "community.openstack.org/openstack" \
-       --plugins lirt/velero-plugin-for-openstack:v0.3.1 \
+       --plugins lirt/velero-plugin-for-openstack:v0.4.0 \
        --bucket <BUCKET_NAME> \
        --no-secret
 
 # Or add plugin to existing velero:
-velero plugin add lirt/velero-plugin-for-openstack:v0.3.1
+velero plugin add lirt/velero-plugin-for-openstack:v0.4.0
 ```
 
-Note: If you want to use plugin built for `arm` or `arm64` architecture, you can use tag such as this `lirt/velero-plugin-for-openstack:v0.3.1-arm64`.
+Note: If you want to use plugin built for `arm` or `arm64` architecture, you can use tag such as this `lirt/velero-plugin-for-openstack:v0.4.0-arm64`.
 
 Change configuration of `backupstoragelocations.velero.io`:
 
@@ -172,7 +173,7 @@ configuration:
     # caCert: <CERT_CONTENTS_IN_BASE64>
 initContainers:
 - name: velero-plugin-openstack
-  image: lirt/velero-plugin-for-openstack:v0.3.1
+  image: lirt/velero-plugin-for-openstack:v0.4.0
   imagePullPolicy: IfNotPresent
   volumeMounts:
     - mountPath: /target
@@ -219,9 +220,10 @@ go mod tidy
 go build
 
 # Build image
-docker buildx --file docker/Dockerfile \
+docker buildx build \
+              --file docker/Dockerfile \
               --platform "linux/amd64" \
-              --tag lirt/velero-plugin-for-openstack:v0.3.1 \
+              --tag lirt/velero-plugin-for-openstack:v0.4.0 \
               --load \
               .
 
@@ -229,7 +231,7 @@ docker buildx --file docker/Dockerfile \
 docker buildx build \
               --file docker/Dockerfile \
               --platform linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 \
-              --tag lirt/velero-plugin-for-openstack:v0.3.1 \
+              --tag lirt/velero-plugin-for-openstack:v0.4.0 \
               --push \
               .
 
@@ -239,7 +241,7 @@ docker buildx build \
 for platform in linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64; do
     docker buildx build \
                   --file docker/Dockerfile \
-                  --tag lirt/velero-plugin-for-openstack:v0.3.1 \
+                  --tag lirt/velero-plugin-for-openstack:v0.4.0 \
                   --platform "${platform}" \
                   --load \
                   .

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,6 +7,7 @@
 * [`v0.2.1` (Dockerfile)](https://github.com/Lirt/velero-plugin-for-openstack/blob/v0.2.1/docker/Dockerfile)
 * [`v0.3.0` (Dockerfile)](https://github.com/Lirt/velero-plugin-for-openstack/blob/v0.3.0/docker/Dockerfile)
 * [`v0.3.1` (Dockerfile)](https://github.com/Lirt/velero-plugin-for-openstack/blob/v0.3.1/docker/Dockerfile)
+* [`v0.4.0` (Dockerfile)](https://github.com/Lirt/velero-plugin-for-openstack/blob/v0.4.0/docker/Dockerfile)
 
 # Velero plugin for OpenStack
 

--- a/src/cinder/block_store.go
+++ b/src/cinder/block_store.go
@@ -3,6 +3,7 @@ package cinder
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"strconv"
 
 	"github.com/Lirt/velero-plugin-swift/src/utils"
@@ -46,14 +47,23 @@ func (b *BlockStore) Init(config map[string]string) error {
 		return fmt.Errorf("failed to authenticate against openstack: %v", err)
 	}
 
-	if b.client == nil {
-		region := utils.GetEnv("OS_REGION_NAME", "")
+	// If we haven't set client before or we use multiple clouds - get new client
+	if b.client == nil || config["cloud"] != "" {
+		region, ok := os.LookupEnv("OS_REGION_NAME")
+		if !ok {
+			if config["region"] != "" {
+				region = config["region"]
+			} else {
+				region = "RegionOne"
+			}
+		}
 		b.client, err = openstack.NewBlockStorageV3(b.provider, gophercloud.EndpointOpts{
 			Region: region,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create cinder storage client: %v", err)
 		}
+		b.log.Infof("Successfully created service client with endpoint %v using region %v", b.client.Endpoint, region)
 	}
 
 	return nil

--- a/src/cinder/block_store.go
+++ b/src/cinder/block_store.go
@@ -41,7 +41,7 @@ func (b *BlockStore) Init(config map[string]string) error {
 	b.config = config
 
 	// Authenticate to Openstack
-	err := utils.Authenticate(&b.provider, "cinder", b.log)
+	err := utils.Authenticate(&b.provider, "cinder", config, b.log)
 	if err != nil {
 		return fmt.Errorf("failed to authenticate against openstack: %v", err)
 	}

--- a/src/swift/object_store.go
+++ b/src/swift/object_store.go
@@ -35,10 +35,18 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		return fmt.Errorf("failed to authenticate against Openstack: %v", err)
 	}
 
-	if o.client == nil {
+	// If we haven't set client before or we use multiple clouds - get new client
+	if o.client == nil || config["cloud"] != "" {
 		region, ok := os.LookupEnv("OS_SWIFT_REGION_NAME")
 		if !ok {
-			region = utils.GetEnv("OS_REGION_NAME", "")
+			region, ok = os.LookupEnv("OS_REGION_NAME")
+			if !ok {
+				if config["region"] != "" {
+					region = config["region"]
+				} else {
+					region = "RegionOne"
+				}
+			}
 		}
 		o.client, err = openstack.NewObjectStorageV1(o.provider, gophercloud.EndpointOpts{
 			Region: region,
@@ -46,6 +54,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create swift storage object: %v", err)
 		}
+		o.log.Infof("Successfully created service client with endpoint %v using region %v", o.client.Endpoint, region)
 	}
 
 	return nil

--- a/src/swift/object_store.go
+++ b/src/swift/object_store.go
@@ -30,7 +30,7 @@ func NewObjectStore(log logrus.FieldLogger) *ObjectStore {
 func (o *ObjectStore) Init(config map[string]string) error {
 	o.log.Infof("ObjectStore.Init called")
 
-	err := utils.Authenticate(&o.provider, "swift", o.log)
+	err := utils.Authenticate(&o.provider, "swift", config, o.log)
 	if err != nil {
 		return fmt.Errorf("failed to authenticate against Openstack: %v", err)
 	}

--- a/src/utils/auth.go
+++ b/src/utils/auth.go
@@ -14,21 +14,22 @@ import (
 
 // Authenticate to Openstack and write client result to **pc
 func Authenticate(pc **gophercloud.ProviderClient, service string, config map[string]string, log logrus.FieldLogger) error {
-	// If service client is already initialized and contains auth result
-	// we know we were already authenticated
-	if *pc != nil {
-		clientAuthResult := (*pc).GetAuthResult()
-		if clientAuthResult != nil {
-			return nil
-		}
-	}
-
 	var err error
 	var clientOpts clientconfig.ClientOpts
 
+	// If we authenticate against multiple clouds, we cannot use reauthentication
 	if cloud, ok := config["cloud"]; ok {
 		log.Infof("Authentication will be done for cloud %v", cloud)
 		clientOpts.Cloud = cloud
+	} else {
+		// If service client is already initialized and contains auth result
+		// we know we were already authenticated
+		if *pc != nil {
+			clientAuthResult := (*pc).GetAuthResult()
+			if clientAuthResult != nil {
+				return nil
+			}
+		}
 	}
 
 	if _, ok := os.LookupEnv("OS_SWIFT_AUTH_URL"); ok && service == "swift" {

--- a/src/utils/auth.go
+++ b/src/utils/auth.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Authenticate to Openstack and write client result to **pc
-func Authenticate(pc **gophercloud.ProviderClient, service string, log logrus.FieldLogger) error {
+func Authenticate(pc **gophercloud.ProviderClient, service string, config map[string]string, log logrus.FieldLogger) error {
 	// If service client is already initialized and contains auth result
 	// we know we were already authenticated
 	if *pc != nil {
@@ -26,8 +26,14 @@ func Authenticate(pc **gophercloud.ProviderClient, service string, log logrus.Fi
 	var err error
 	var clientOpts clientconfig.ClientOpts
 
+	if cloud, ok := config["cloud"]; ok {
+		log.Infof("Authentication will be done for cloud %v", cloud)
+		clientOpts.Cloud = cloud
+	}
+
 	if _, ok := os.LookupEnv("OS_SWIFT_AUTH_URL"); ok && service == "swift" {
-		log.Infof("Authenticating against Swift using special swift environment variables (see README.md)")
+		log.Infof("Trying to authenticate against SwiftStack using special swift environment variables (see README.md)")
+
 		clientOpts.AuthInfo = &clientconfig.AuthInfo{
 			ApplicationCredentialID:     os.Getenv("OS_SWIFT_APPLICATION_CREDENTIAL_ID"),
 			ApplicationCredentialName:   os.Getenv("OS_SWIFT_APPLICATION_CREDENTIAL_NAME"),
@@ -67,7 +73,7 @@ func Authenticate(pc **gophercloud.ProviderClient, service string, log logrus.Fi
 	if err != nil {
 		return err
 	}
-	log.Infof("Authentication successful")
+	log.Infof("Authentication against identity endpoint %v was successful", (*pc).IdentityEndpoint)
 
 	return nil
 }


### PR DESCRIPTION
If we specify multiple clouds for example into clouds.yaml file, we need to have a way how to pick which cloud to use for specific backup. For this we can set cloud name into BackupStorageLocation or VolumeSnapshotLocation and plugin will pick which cloud to use for authentication and further operations.

Signed-off-by: Ondrej Vasko <ondrej.vaskoo@gmail.com>