### PR TITLE
Add an ability to set a static Temp URL key

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ export OS_APPLICATION_CREDENTIAL_SECRET=<APP_CRED_SECRET>
 export OS_VERIFY="false"
 export TLS_SKIP_VERIFY="true"
 
+# A custom hash function to use for Temp URL generation
+export OS_SWIFT_TEMP_URL_DIGEST=sha256
 # If you want to override Swift account ID
 export OS_SWIFT_ACCOUNT_OVERRIDE=<NEW_PROJECT_ID>
 # In case if you have non-standard reseller prefixes

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Lirt/velero-plugin-swift
 go 1.19
 
 require (
-	github.com/gophercloud/gophercloud v1.0.0
+	github.com/gophercloud/gophercloud v1.3.1-0.20230331133731-6e0b5eac8554
 	github.com/gophercloud/utils v0.0.0-20220927104426-4113af8d2663
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gophercloud/gophercloud v0.20.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
-github.com/gophercloud/gophercloud v1.0.0 h1:9nTGx0jizmHxDobe4mck89FyQHVyA3CaXLIUSGJjP9k=
-github.com/gophercloud/gophercloud v1.0.0/go.mod h1:Q8fZtyi5zZxPS/j9aj3sSxtvj41AdQMDwyo1myduD5c=
+github.com/gophercloud/gophercloud v1.3.1-0.20230331133731-6e0b5eac8554 h1:NITuyeCL/cDy/CSR38VaiY3sWBKJPGtt2yBWjPes4cU=
+github.com/gophercloud/gophercloud v1.3.1-0.20230331133731-6e0b5eac8554/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gophercloud/utils v0.0.0-20220927104426-4113af8d2663 h1:cHUPA6mgL0RGwopSxYRil6v8mK4ab6yefs1PJRXPXUE=
 github.com/gophercloud/utils v0.0.0-20220927104426-4113af8d2663/go.mod h1:qOGlfG6OIJ193/c3Xt/XjOfHataNZdQcVgiu93LxBUM=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
@@ -338,9 +338,9 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20211202192323-5770296d904e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd h1:XcWmESyNjXJMLahc3mqVQJcgSTDxFxhETVlfk9uGc38=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/src/cinder/block_store.go
+++ b/src/cinder/block_store.go
@@ -41,10 +41,10 @@ func (b *BlockStore) Init(config map[string]string) error {
 	b.log.Infof("BlockStore.Init called", config)
 	b.config = config
 
-	// Authenticate to Openstack
+	// Authenticate to OpenStack
 	err := utils.Authenticate(&b.provider, "cinder", config, b.log)
 	if err != nil {
-		return fmt.Errorf("failed to authenticate against openstack: %v", err)
+		return fmt.Errorf("failed to authenticate against OpenStack: %v", err)
 	}
 
 	// If we haven't set client before or we use multiple clouds - get new client

--- a/src/swift/object_store.go
+++ b/src/swift/object_store.go
@@ -18,9 +18,10 @@ import (
 
 // ObjectStore is swift type that holds client and log
 type ObjectStore struct {
-	client   *gophercloud.ServiceClient
-	provider *gophercloud.ProviderClient
-	log      logrus.FieldLogger
+	client     *gophercloud.ServiceClient
+	provider   *gophercloud.ProviderClient
+	log        logrus.FieldLogger
+	tempURLKey string
 }
 
 // NewObjectStore instantiates a Swift ObjectStore.
@@ -34,7 +35,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 
 	err := utils.Authenticate(&o.provider, "swift", config, o.log)
 	if err != nil {
-		return fmt.Errorf("failed to authenticate against Openstack: %v", err)
+		return fmt.Errorf("failed to authenticate against OpenStack: %v", err)
 	}
 
 	// If we haven't set client before or we use multiple clouds - get new client
@@ -81,6 +82,12 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		o.client.Endpoint = u.String()
 		o.client.ResourceBase = ""
 		o.log.Infof("Successfully overrode service client endpoint: %v", o.client.Endpoint)
+	}
+
+	// override the Temp URL key to generate a URL signature
+	o.tempURLKey = utils.GetEnv("OS_SWIFT_TEMP_URL_KEY", "")
+	if o.tempURLKey != "" {
+		o.log.Infof("Successfully overrode Temp URL key")
 	}
 
 	return nil
@@ -216,8 +223,9 @@ func (o *ObjectStore) CreateSignedURL(container, object string, ttl time.Duratio
 	log.Infof("CreateSignedURL")
 
 	url, err := objects.CreateTempURL(o.client, container, object, objects.CreateTempURLOpts{
-		Method: http.MethodGet,
-		TTL:    int(ttl.Seconds()),
+		Method:     http.MethodGet,
+		TTL:        int(ttl.Seconds()),
+		TempURLKey: o.tempURLKey,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary URL for %q object in %q container: %v", object, container, err)

--- a/src/utils/auth.go
+++ b/src/utils/auth.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Authenticate to Openstack and write client result to **pc
+// Authenticate to OpenStack and write client result to **pc
 func Authenticate(pc **gophercloud.ProviderClient, service string, config map[string]string, log logrus.FieldLogger) error {
 	var err error
 	var clientOpts clientconfig.ClientOpts
@@ -54,7 +54,7 @@ func Authenticate(pc **gophercloud.ProviderClient, service string, config map[st
 			AllowReauth:                 true,
 		}
 	} else {
-		log.Infof("Trying to authenticate against Openstack using environment variables (including application credentials) or using files ~/.config/openstack/clouds.yaml, /etc/openstack/clouds.yaml and ./clouds.yaml")
+		log.Infof("Trying to authenticate against OpenStack using environment variables (including application credentials) or using files ~/.config/openstack/clouds.yaml, /etc/openstack/clouds.yaml and ./clouds.yaml")
 		clientOpts.AuthInfo = &clientconfig.AuthInfo{
 			AllowReauth: true,
 		}


### PR DESCRIPTION
Fixes #58 + adjusts the `OpenStack` naming style
I also added an option for a custom hash function, since the default sha1 is already marked as deprecated.