### PR TITLE
Rewrite logs with JSON fields

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,6 @@
 ---
 name: Integration tests with Kind and DevStack
-on: [push, pull_request]
+on: [push]
 jobs:
   unit-test:
     name: "Unit tests (go v${{ matrix.go-version }})"


### PR DESCRIPTION
Logs are currently not formatted well. When complex structure is output to log it usually contains %EXTRA string and incorrect formatted log. This change will make logs to be JSON formatted and don't output unnecessary strings.