### PR TITLE
Preserve metadata on snapshot restore

### DIFF
--- a/src/utils/helpers.go
+++ b/src/utils/helpers.go
@@ -96,3 +96,25 @@ func microversionToInt(mv string) ([]int, error) {
 	}
 	return nil, fmt.Errorf("invalid microversion string: %v", mv)
 }
+
+// SliceContains checks whether a slice of comparable type contains an element
+func SliceContains[T comparable](elems []T, e T) bool {
+	for _, v := range elems {
+		if v == e {
+			return true
+		}
+	}
+	return false
+}
+
+// Merge merges maps. If more than one given map with the same key, then the
+// one that is later in the argument sequence takes precedence
+func Merge(args ...map[string]string) map[string]string {
+	m := make(map[string]string)
+	for _, arg := range args {
+		for k, v := range arg {
+			m[k] = v
+		}
+	}
+	return m
+}

--- a/src/utils/helpers_test.go
+++ b/src/utils/helpers_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -99,6 +100,33 @@ func TestCompareMicroversions(t *testing.T) {
 			t.Errorf("[%d] test failed: %v", i, err)
 		} else if test.res != v {
 			t.Errorf("[%d] test failed: expected %t, got %t", i, test.res, v)
+		}
+	}
+}
+
+func TestMerge(t *testing.T) {
+	tests := map[*map[string]string][]map[string]string{
+		&(map[string]string{
+			"a": "c",
+			"b": "c",
+			"c": "d",
+		}): {
+			{
+				"a": "b",
+				"c": "d",
+			},
+			{
+				"a": "c",
+			},
+			{
+				"b": "c",
+			},
+		},
+	}
+
+	for d, s := range tests {
+		if m := Merge(s...); !reflect.DeepEqual(*d, m) {
+			t.Errorf("test failed: expected %q, got %q", *d, m)
 		}
 	}
 }


### PR DESCRIPTION
Resolves #70 

Tags are set from backup labels, which are specified in `velero backup create --labels foo=bar`