### PR TITLE
Use backup name for the cinder backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ configuration:
       # allowing the source volume to be deleted (EXPERIMENTAL)
       # * "image" is for a full volume backup uploaded to a Glance image
       # allowing the source volume to be deleted (EXPERIMENTAL)
+      # requires the "enable_force_upload" Cinder option to be enabled on the server
       method: clone
       # optional resource readiness timeouts in Golang time format: https://pkg.go.dev/time#ParseDuration
       # (default: 5m)

--- a/src/cinder/block_store.go
+++ b/src/cinder/block_store.go
@@ -581,6 +581,7 @@ func (b *BlockStore) createBackup(volumeID, volumeAZ string, tags map[string]str
 	}
 
 	opts := &backups.CreateOpts{
+		Name:        backupName,
 		VolumeID:    volumeID,
 		Description: "Velero volume backup",
 		Container:   backupName,


### PR DESCRIPTION
Add missed backup name
Added an extra comment for the cinder image upload method

The issue was introduced in #89