### PR TITLE
Tests: Do not upgrade CRDs in velero helm chart

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -153,6 +153,7 @@ jobs:
                --version "${VELERO_CHART_VERSION}" \
                --values "${TESTS_DIRECTORY}/velero-helm-values.yaml" \
                --set "initContainers[0].image=${DOCKER_IMAGE_NAME}:${GITHUB_SHA}" \
+               --set "upgradeCRDs=false" \
                --timeout 10m \
                --wait \
                --wait-for-jobs


### PR DESCRIPTION
Integration test is always freshly executed therefore it doesn't need to run Velero job to upgrade CRDs.

Upgrade CRDs job has an unconfirmed bug that prevents CI from successing (https://github.com/vmware-tanzu/helm-charts/issues/559).