### PR TITLE
Set default region back to empty string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.so
 *.dylib
 
+velero-plugin-for-openstack
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Recommended way of using this plugin with restic is to use authentication with e
 
 ```bash
 # test and build code
-go test -v ./...
+go test -v -count 1 ./...
 go mod tidy
 go build
 

--- a/docs/installation-using-cli.md
+++ b/docs/installation-using-cli.md
@@ -46,6 +46,14 @@ metadata:
 spec:
   provider: community.openstack.org/openstack-cinder
   config:
+    # optional Cloud:
+    #   in case clouds.yaml is used as authentication method, cloud allows
+    #   user to select which cloud from the clouds.yaml to use for volume backups
+    cloud: "myCloud"
+    # optional Region:
+    #   in case multiple regions exist in a single cloud, select which region
+    #   will be used for backups.
+    region: "myRegion"
     # optional snapshot method:
     # * "snapshot" is a default cinder snapshot method
     # * "clone" is for a full volume clone instead of a snapshot allowing the
@@ -89,6 +97,14 @@ metadata:
 spec:
   provider: community.openstack.org/openstack-manila
   config:
+    # optional Cloud:
+    #   in case clouds.yaml is used as authentication method, cloud allows
+    #   user to select which cloud from the clouds.yaml to use for volume backups
+    cloud: "myCloud"
+    # optional Region:
+    #   in case multiple regions exist in a single cloud, select which region
+    #   will be used for backups.
+    region: "myRegion"
     # optional snapshot method:
     # * "snapshot" is a default manila snapshot method
     # * "clone" is for a full share clone instead of a snapshot allowing the

--- a/docs/installation-using-cli.md
+++ b/docs/installation-using-cli.md
@@ -49,11 +49,11 @@ spec:
     # optional Cloud:
     #   in case clouds.yaml is used as authentication method, cloud allows
     #   user to select which cloud from the clouds.yaml to use for volume backups
-    cloud: "myCloud"
+    cloud: ""
     # optional Region:
     #   in case multiple regions exist in a single cloud, select which region
     #   will be used for backups.
-    region: "myRegion"
+    region: ""
     # optional snapshot method:
     # * "snapshot" is a default cinder snapshot method
     # * "clone" is for a full volume clone instead of a snapshot allowing the
@@ -100,11 +100,11 @@ spec:
     # optional Cloud:
     #   in case clouds.yaml is used as authentication method, cloud allows
     #   user to select which cloud from the clouds.yaml to use for volume backups
-    cloud: "myCloud"
+    cloud: ""
     # optional Region:
     #   in case multiple regions exist in a single cloud, select which region
     #   will be used for backups.
-    region: "myRegion"
+    region: ""
     # optional snapshot method:
     # * "snapshot" is a default manila snapshot method
     # * "clone" is for a full share clone instead of a snapshot allowing the

--- a/docs/installation-using-cli.md
+++ b/docs/installation-using-cli.md
@@ -52,7 +52,7 @@ spec:
     cloud: ""
     # optional Region:
     #   in case multiple regions exist in a single cloud, select which region
-    #   will be used for backups.
+    #   will be used for cinder volume backups.
     region: ""
     # optional snapshot method:
     # * "snapshot" is a default cinder snapshot method
@@ -98,12 +98,12 @@ spec:
   provider: community.openstack.org/openstack-manila
   config:
     # optional Cloud:
-    #   in case clouds.yaml is used as authentication method, cloud allows
-    #   user to select which cloud from the clouds.yaml to use for volume backups
+    #   in case clouds.yaml is used as authentication method, cloud allows user
+    #   to select which cloud from the clouds.yaml to use for manila share backups
     cloud: ""
     # optional Region:
     #   in case multiple regions exist in a single cloud, select which region
-    #   will be used for backups.
+    #   will be used for manila share backups.
     region: ""
     # optional snapshot method:
     # * "snapshot" is a default manila snapshot method

--- a/docs/installation-using-helm.md
+++ b/docs/installation-using-helm.md
@@ -34,7 +34,7 @@ configuration:
       cloud: ""
       # optional Region:
       #   in case multiple regions exist in a single cloud, select which region
-      #   will be used for backups.
+      #   will be used for cinder volume backups.
       region: ""
       # optional snapshot method:
       # * "snapshot" is a default cinder snapshot method
@@ -70,12 +70,12 @@ configuration:
     provider: community.openstack.org/openstack-manila
     config:
       # optional Cloud:
-      #   in case clouds.yaml is used as authentication method, cloud allows
-      #   user to select which cloud from the clouds.yaml to use for volume backups
+      #   in case clouds.yaml is used as authentication method, cloud allows user
+      #   to select which cloud from the clouds.yaml to use for manila share backups
       cloud: ""
       # optional Region:
       #   in case multiple regions exist in a single cloud, select which region
-      #   will be used for backups.
+      #   will be used for manila share backups.
       region: ""
       # optional snapshot method:
       # * "snapshot" is a default manila snapshot method

--- a/docs/installation-using-helm.md
+++ b/docs/installation-using-helm.md
@@ -28,6 +28,14 @@ configuration:
   - name: cinder
     provider: community.openstack.org/openstack-cinder
     config:
+      # optional Cloud:
+      #   in case clouds.yaml is used as authentication method, cloud allows
+      #   user to select which cloud from the clouds.yaml to use for volume backups
+      cloud: "myCloud"
+      # optional Region:
+      #   in case multiple regions exist in a single cloud, select which region
+      #   will be used for backups.
+      region: "myRegion"
       # optional snapshot method:
       # * "snapshot" is a default cinder snapshot method
       # * "clone" is for a full volume clone instead of a snapshot allowing the
@@ -61,6 +69,14 @@ configuration:
   - name: manila
     provider: community.openstack.org/openstack-manila
     config:
+      # optional Cloud:
+      #   in case clouds.yaml is used as authentication method, cloud allows
+      #   user to select which cloud from the clouds.yaml to use for volume backups
+      cloud: "myCloud"
+      # optional Region:
+      #   in case multiple regions exist in a single cloud, select which region
+      #   will be used for backups.
+      region: "myRegion"
       # optional snapshot method:
       # * "snapshot" is a default manila snapshot method
       # * "clone" is for a full share clone instead of a snapshot allowing the

--- a/docs/installation-using-helm.md
+++ b/docs/installation-using-helm.md
@@ -31,11 +31,11 @@ configuration:
       # optional Cloud:
       #   in case clouds.yaml is used as authentication method, cloud allows
       #   user to select which cloud from the clouds.yaml to use for volume backups
-      cloud: "myCloud"
+      cloud: ""
       # optional Region:
       #   in case multiple regions exist in a single cloud, select which region
       #   will be used for backups.
-      region: "myRegion"
+      region: ""
       # optional snapshot method:
       # * "snapshot" is a default cinder snapshot method
       # * "clone" is for a full volume clone instead of a snapshot allowing the
@@ -72,11 +72,11 @@ configuration:
       # optional Cloud:
       #   in case clouds.yaml is used as authentication method, cloud allows
       #   user to select which cloud from the clouds.yaml to use for volume backups
-      cloud: "myCloud"
+      cloud: ""
       # optional Region:
       #   in case multiple regions exist in a single cloud, select which region
       #   will be used for backups.
-      region: "myRegion"
+      region: ""
       # optional snapshot method:
       # * "snapshot" is a default manila snapshot method
       # * "clone" is for a full share clone instead of a snapshot allowing the

--- a/src/cinder/block_store.go
+++ b/src/cinder/block_store.go
@@ -175,7 +175,7 @@ func (b *BlockStore) Init(config map[string]string) error {
 			if config["region"] != "" {
 				region = config["region"]
 			} else {
-				region = "RegionOne"
+				region = ""
 			}
 		}
 		b.client, err = openstack.NewBlockStorageV3(b.provider, gophercloud.EndpointOpts{

--- a/src/cinder/block_store_test.go
+++ b/src/cinder/block_store_test.go
@@ -145,6 +145,11 @@ const tokenResp = `{
     }
 }`
 
+// TestInit performs standard block store initialization
+// which includes creation of auth client, authentication and
+// creation of block storage client.
+// In this test we use simple clouds.yaml and don't override
+// any option.
 func TestInit(t *testing.T) {
 	// Basic structs
 	log := logrus.New()

--- a/src/cinder/block_store_test.go
+++ b/src/cinder/block_store_test.go
@@ -1,0 +1,178 @@
+package cinder
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fakeClient "github.com/gophercloud/gophercloud/testhelper/client"
+	"github.com/sirupsen/logrus"
+)
+
+const ID = "0123456789"
+const tokenResp = `{
+    "token": {
+        "audit_ids": ["VcxU2JYqT8OzfUVvrjEITQ", "qNUTIJntTzO1-XUk5STybw"],
+        "catalog": [
+            {
+                "endpoints": [
+                    {
+                        "id": "796186fced4611ee9e2c9cb6d0fbac9d",
+                        "interface": "public",
+                        "region": "RegionOne",
+                        "url": "http://localhost:5000"
+                    },
+                    {
+                        "id": "7c2bb2cced4611ee90c09cb6d0fbac9d",
+                        "interface": "internal",
+                        "region": "RegionOne",
+                        "url": "http://localhost:5000"
+                    },
+                    {
+                        "id": "8080e7b6ed4611ee88be9cb6d0fbac9d",
+                        "interface": "admin",
+                        "region": "RegionOne",
+                        "url": "http://localhost:35357"
+                    }
+                ],
+                "id": "854d03ceed4611ee82b09cb6d0fbac9d", 
+                "type": "identity", 
+                "name": "keystone"
+            },
+            {
+                "endpoints": [
+                    {
+                        "id": "5fb3e04cc47345079bcccfa5a78d4de6",
+                        "interface": "internal",
+                        "region_id": "myRegion",
+                        "url": "http://localhost:8776/v3/955f0136ed4611ee9f489cb6d0fbac9d",
+                        "region": "myRegion"
+                    },
+                    {
+                        "id": "d48c520ef7b941c692100f24a1437864",
+                        "interface": "public",
+                        "region_id": "myRegion",
+                        "url": "https://localhost:8776/v3/955f0136ed4611ee9f489cb6d0fbac9d",
+                        "region": "myRegion"
+                    },
+                    {
+                        "id": "da15876d31f24af3afc3a69cb918c45f",
+                        "interface": "admin",
+                        "region_id": "myRegion",
+                        "url": "https://localhost:8776/v3/955f0136ed4611ee9f489cb6d0fbac9d",
+                        "region": "myRegion"
+                    }
+                ],
+                "id": "439e9f0d9d224b88a9b01774a9948e5e",
+                "type": "volumev3",
+                "name": "cinderv3"
+            },
+            {
+                "endpoints": [
+                    {
+                        "id": "2bed9ab4ed4111eeb4229cb6d0fbac9d",
+                        "interface": "internal",
+                        "region_id": "secondRegion",
+                        "url": "http://localhost2:8776/v3/4c30519aed4111eeab909cb6d0fbac9d",
+                        "region": "secondRegion"
+                    },
+                    {
+                        "id": "3bd7f8caed4111eeb77a9cb6d0fbac9d",
+                        "interface": "public",
+                        "region_id": "secondRegion",
+                        "url": "https://localhost2:8776/v3/4c30519aed4111eeab909cb6d0fbac9d",
+                        "region": "secondRegion"
+                    },
+                    {
+                        "id": "46474c98ed4111eeb2839cb6d0fbac9d",
+                        "interface": "admin",
+                        "region_id": "secondRegion",
+                        "url": "https://localhost2:8776/v3/4c30519aed4111eeab909cb6d0fbac9d",
+                        "region": "secondRegion"
+                    }
+                ],
+                "id": "4c30519aed4111eeab909cb6d0fbac9d",
+                "type": "volumev3",
+                "name": "cinderv3"
+            }
+        ],
+        "expires_at": "2025-02-27T18:30:59.999999Z",
+        "is_domain": false,
+        "issued_at": "2025-02-27T16:30:59.999999Z",
+        "methods": [
+            "password"
+        ],
+        "project": {
+            "domain": {
+                "id": "8789d1",
+                "name": "example.com"
+            },
+            "id": "263fa9",
+            "name": "project-y"
+        },
+        "roles": [
+            {
+                "id": "86e72a",
+                "name": "admin"
+            },
+            {
+                "id": "e4f392",
+                "name": "member"
+            }
+        ],
+        "service_providers": [
+            {
+                "auth_url":"https://example.com:5000/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+                "id": "sp1",
+                "sp_url": "https://example.com:5000/Shibboleth.sso/SAML2/ECP"
+            },
+            {
+                "auth_url":"https://other.example.com:5000/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+                "id": "sp2",
+                "sp_url": "https://other.example.com:5000/Shibboleth.sso/SAML2/ECP"
+            }
+        ],
+        "user": {
+            "domain": {
+                "id": "8789d1",
+                "name": "example.com"
+            },
+            "id": "0ca8f6",
+            "name": "Jane",
+            "password_expires_at": "2026-11-06T15:32:17.000000"
+        }
+    }
+}`
+
+func TestInit(t *testing.T) {
+	// Basic structs
+	log := logrus.New()
+	config := map[string]string{
+		"cloud": "myCloud",
+	}
+	bs := NewBlockStore(log)
+
+	// Create fake provider client for authentication,
+	// prepare handler for authentication and redirect
+	// provider endpoint to fake client.
+	th.SetupPersistentPortHTTP(t, 32498)
+	defer th.TeardownHTTP()
+	fakeClient.ServiceClient()
+	bs.provider = fakeClient.ServiceClient().ProviderClient
+	bs.provider.IdentityEndpoint = th.Endpoint()
+
+	th.Mux.HandleFunc("/v3/auth/tokens",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("X-Subject-Token", ID)
+
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, tokenResp)
+		},
+	)
+
+	// Try to Init block storage. This involves authentication.
+	if err := bs.Init(config); err != nil {
+		t.Error(err)
+	}
+}

--- a/src/cinder/block_store_test.go
+++ b/src/cinder/block_store_test.go
@@ -36,8 +36,8 @@ const tokenResp = `{
                         "url": "http://localhost:35357"
                     }
                 ],
-                "id": "854d03ceed4611ee82b09cb6d0fbac9d", 
-                "type": "identity", 
+                "id": "854d03ceed4611ee82b09cb6d0fbac9d",
+                "type": "identity",
                 "name": "keystone"
             },
             {
@@ -106,10 +106,10 @@ const tokenResp = `{
         "project": {
             "domain": {
                 "id": "8789d1",
-                "name": "example.com"
+                "name": "domain"
             },
-            "id": "263fa9",
-            "name": "project-y"
+            "id": "04982538-f42b-11ee-a412-9cb6d0fbac9d",
+            "name": "project"
         },
         "roles": [
             {
@@ -121,25 +121,13 @@ const tokenResp = `{
                 "name": "member"
             }
         ],
-        "service_providers": [
-            {
-                "auth_url":"https://example.com:5000/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
-                "id": "sp1",
-                "sp_url": "https://example.com:5000/Shibboleth.sso/SAML2/ECP"
-            },
-            {
-                "auth_url":"https://other.example.com:5000/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
-                "id": "sp2",
-                "sp_url": "https://other.example.com:5000/Shibboleth.sso/SAML2/ECP"
-            }
-        ],
         "user": {
             "domain": {
                 "id": "8789d1",
-                "name": "example.com"
+                "name": "domain"
             },
-            "id": "0ca8f6",
-            "name": "Jane",
+            "id": "cf78e694-f42a-11ee-bfcc-9cb6d0fbac9d",
+            "name": "user",
             "password_expires_at": "2026-11-06T15:32:17.000000"
         }
     }
@@ -148,9 +136,9 @@ const tokenResp = `{
 // TestInit performs standard block store initialization
 // which includes creation of auth client, authentication and
 // creation of block storage client.
-// In this test we use simple clouds.yaml and don't override
+// In this test we use simple clouds.yaml and not override
 // any option.
-func TestInit(t *testing.T) {
+func TestSimpleBlockStorageInit(t *testing.T) {
 	// Basic structs
 	log := logrus.New()
 	config := map[string]string{

--- a/src/cinder/clouds.yaml
+++ b/src/cinder/clouds.yaml
@@ -1,0 +1,11 @@
+clouds:
+  myCloud:
+    auth:
+      user_domain_name: users
+      auth_url: http://127.0.0.1:32498/v3
+      username: user
+      password: pass
+      project_name: project
+      project_domain_name: domain
+    region_name: myRegion
+    identity_api_version: 3

--- a/src/cinder/clouds.yaml
+++ b/src/cinder/clouds.yaml
@@ -1,3 +1,4 @@
+# This file is only to perform unit test with clouds.yaml for which the path cannot be changed
 clouds:
   myCloud:
     auth:
@@ -7,5 +8,5 @@ clouds:
       password: pass
       project_name: project
       project_domain_name: domain
-    region_name: myRegion
+    # region_name: myRegion
     identity_api_version: 3

--- a/src/manila/clouds.yaml
+++ b/src/manila/clouds.yaml
@@ -3,7 +3,7 @@ clouds:
   myCloud:
     auth:
       user_domain_name: users
-      auth_url: http://127.0.0.1:32498/v3
+      auth_url: http://127.0.0.1:32499/v3
       username: user
       password: pass
       project_name: project

--- a/src/manila/clouds.yaml
+++ b/src/manila/clouds.yaml
@@ -1,0 +1,12 @@
+# This file is only to perform unit test with clouds.yaml for which the path cannot be changed
+clouds:
+  myCloud:
+    auth:
+      user_domain_name: users
+      auth_url: http://127.0.0.1:32498/v3
+      username: user
+      password: pass
+      project_name: project
+      project_domain_name: domain
+    # region_name: myRegion
+    identity_api_version: 3

--- a/src/manila/fs_store.go
+++ b/src/manila/fs_store.go
@@ -154,7 +154,7 @@ func (b *FSStore) Init(config map[string]string) error {
 			if config["region"] != "" {
 				region = config["region"]
 			} else {
-				region = "RegionOne"
+				region = ""
 			}
 		}
 		b.client, err = openstack.NewSharedFileSystemV2(b.provider, gophercloud.EndpointOpts{

--- a/src/manila/fs_store_test.go
+++ b/src/manila/fs_store_test.go
@@ -36,8 +36,8 @@ const tokenResp = `{
                         "url": "http://localhost:35357"
                     }
                 ],
-                "id": "854d03ceed4611ee82b09cb6d0fbac9d", 
-                "type": "identity", 
+                "id": "854d03ceed4611ee82b09cb6d0fbac9d",
+                "type": "identity",
                 "name": "keystone"
             },
             {
@@ -106,10 +106,10 @@ const tokenResp = `{
         "project": {
             "domain": {
                 "id": "8789d1",
-                "name": "example.com"
+                "name": "domain"
             },
-            "id": "263fa9",
-            "name": "project-y"
+            "id": "04982538-f42b-11ee-a412-9cb6d0fbac9d",
+            "name": "project"
         },
         "roles": [
             {
@@ -121,36 +121,24 @@ const tokenResp = `{
                 "name": "member"
             }
         ],
-        "service_providers": [
-            {
-                "auth_url":"https://example.com:5000/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
-                "id": "sp1",
-                "sp_url": "https://example.com:5000/Shibboleth.sso/SAML2/ECP"
-            },
-            {
-                "auth_url":"https://other.example.com:5000/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
-                "id": "sp2",
-                "sp_url": "https://other.example.com:5000/Shibboleth.sso/SAML2/ECP"
-            }
-        ],
         "user": {
             "domain": {
                 "id": "8789d1",
-                "name": "example.com"
+                "name": "domain"
             },
-            "id": "0ca8f6",
-            "name": "Jane",
+            "id": "cf78e694-f42a-11ee-bfcc-9cb6d0fbac9d",
+            "name": "user",
             "password_expires_at": "2026-11-06T15:32:17.000000"
         }
     }
 }`
 
-// TestInit performs standard block store initialization
+// TestInit performs standard file share store initialization
 // which includes creation of auth client, authentication and
-// creation of block storage client.
-// In this test we use simple clouds.yaml and don't override
-// any option.
-func TestInit(t *testing.T) {
+// creation of shared filesystem client.
+// In this test we use simple clouds.yaml and not override
+// any options.
+func TestSimpleSharedFilesystemInit(t *testing.T) {
 	// Basic structs
 	log := logrus.New()
 	config := map[string]string{
@@ -161,7 +149,7 @@ func TestInit(t *testing.T) {
 	// Create fake provider client for authentication,
 	// prepare handler for authentication and redirect
 	// provider endpoint to fake client.
-	th.SetupPersistentPortHTTP(t, 32498)
+	th.SetupPersistentPortHTTP(t, 32499)
 	defer th.TeardownHTTP()
 	fakeClient.ServiceClient()
 	fs.provider = fakeClient.ServiceClient().ProviderClient

--- a/src/manila/fs_store_test.go
+++ b/src/manila/fs_store_test.go
@@ -1,0 +1,183 @@
+package manila
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fakeClient "github.com/gophercloud/gophercloud/testhelper/client"
+	"github.com/sirupsen/logrus"
+)
+
+const ID = "0123456789"
+const tokenResp = `{
+    "token": {
+        "audit_ids": ["VcxU2JYqT8OzfUVvrjEITQ", "qNUTIJntTzO1-XUk5STybw"],
+        "catalog": [
+            {
+                "endpoints": [
+                    {
+                        "id": "796186fced4611ee9e2c9cb6d0fbac9d",
+                        "interface": "public",
+                        "region": "RegionOne",
+                        "url": "http://localhost:5000"
+                    },
+                    {
+                        "id": "7c2bb2cced4611ee90c09cb6d0fbac9d",
+                        "interface": "internal",
+                        "region": "RegionOne",
+                        "url": "http://localhost:5000"
+                    },
+                    {
+                        "id": "8080e7b6ed4611ee88be9cb6d0fbac9d",
+                        "interface": "admin",
+                        "region": "RegionOne",
+                        "url": "http://localhost:35357"
+                    }
+                ],
+                "id": "854d03ceed4611ee82b09cb6d0fbac9d", 
+                "type": "identity", 
+                "name": "keystone"
+            },
+            {
+                "endpoints": [
+                    {
+                        "id": "5fb3e04cc47345079bcccfa5a78d4de6",
+                        "interface": "internal",
+                        "region_id": "myRegion",
+                        "url": "http://localhost:8786/v3/955f0136ed4611ee9f489cb6d0fbac9d",
+                        "region": "myRegion"
+                    },
+                    {
+                        "id": "d48c520ef7b941c692100f24a1437864",
+                        "interface": "public",
+                        "region_id": "myRegion",
+                        "url": "https://localhost:8786/v3/955f0136ed4611ee9f489cb6d0fbac9d",
+                        "region": "myRegion"
+                    },
+                    {
+                        "id": "da15876d31f24af3afc3a69cb918c45f",
+                        "interface": "admin",
+                        "region_id": "myRegion",
+                        "url": "https://localhost:8786/v3/955f0136ed4611ee9f489cb6d0fbac9d",
+                        "region": "myRegion"
+                    }
+                ],
+                "id": "439e9f0d9d224b88a9b01774a9948e5e",
+                "type": "sharev2",
+                "name": "manilav2"
+            },
+            {
+                "endpoints": [
+                    {
+                        "id": "2bed9ab4ed4111eeb4229cb6d0fbac9d",
+                        "interface": "internal",
+                        "region_id": "secondRegion",
+                        "url": "http://localhost2:8786/v3/4c30519aed4111eeab909cb6d0fbac9d",
+                        "region": "secondRegion"
+                    },
+                    {
+                        "id": "3bd7f8caed4111eeb77a9cb6d0fbac9d",
+                        "interface": "public",
+                        "region_id": "secondRegion",
+                        "url": "https://localhost2:8786/v3/4c30519aed4111eeab909cb6d0fbac9d",
+                        "region": "secondRegion"
+                    },
+                    {
+                        "id": "46474c98ed4111eeb2839cb6d0fbac9d",
+                        "interface": "admin",
+                        "region_id": "secondRegion",
+                        "url": "https://localhost2:8786/v3/4c30519aed4111eeab909cb6d0fbac9d",
+                        "region": "secondRegion"
+                    }
+                ],
+                "id": "4c30519aed4111eeab909cb6d0fbac9d",
+                "type": "sharev2",
+                "name": "manilav2"
+            }
+        ],
+        "expires_at": "2025-02-27T18:30:59.999999Z",
+        "is_domain": false,
+        "issued_at": "2025-02-27T16:30:59.999999Z",
+        "methods": [
+            "password"
+        ],
+        "project": {
+            "domain": {
+                "id": "8789d1",
+                "name": "example.com"
+            },
+            "id": "263fa9",
+            "name": "project-y"
+        },
+        "roles": [
+            {
+                "id": "86e72a",
+                "name": "admin"
+            },
+            {
+                "id": "e4f392",
+                "name": "member"
+            }
+        ],
+        "service_providers": [
+            {
+                "auth_url":"https://example.com:5000/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+                "id": "sp1",
+                "sp_url": "https://example.com:5000/Shibboleth.sso/SAML2/ECP"
+            },
+            {
+                "auth_url":"https://other.example.com:5000/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+                "id": "sp2",
+                "sp_url": "https://other.example.com:5000/Shibboleth.sso/SAML2/ECP"
+            }
+        ],
+        "user": {
+            "domain": {
+                "id": "8789d1",
+                "name": "example.com"
+            },
+            "id": "0ca8f6",
+            "name": "Jane",
+            "password_expires_at": "2026-11-06T15:32:17.000000"
+        }
+    }
+}`
+
+// TestInit performs standard block store initialization
+// which includes creation of auth client, authentication and
+// creation of block storage client.
+// In this test we use simple clouds.yaml and don't override
+// any option.
+func TestInit(t *testing.T) {
+	// Basic structs
+	log := logrus.New()
+	config := map[string]string{
+		"cloud": "myCloud",
+	}
+	fs := NewFSStore(log)
+
+	// Create fake provider client for authentication,
+	// prepare handler for authentication and redirect
+	// provider endpoint to fake client.
+	th.SetupPersistentPortHTTP(t, 32498)
+	defer th.TeardownHTTP()
+	fakeClient.ServiceClient()
+	fs.provider = fakeClient.ServiceClient().ProviderClient
+	fs.provider.IdentityEndpoint = th.Endpoint()
+
+	th.Mux.HandleFunc("/v3/auth/tokens",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("X-Subject-Token", ID)
+
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, tokenResp)
+		},
+	)
+
+	// Try to Init block storage. This involves authentication.
+	if err := fs.Init(config); err != nil {
+		t.Error(err)
+	}
+}

--- a/src/swift/clouds.yaml
+++ b/src/swift/clouds.yaml
@@ -2,8 +2,8 @@
 clouds:
   myCloud:
     auth:
-      user_domain_name: domain
-      auth_url: http://127.0.0.1:32498/v3
+      user_domain_name: users
+      auth_url: http://127.0.0.1:32500/v3
       username: user
       password: pass
       project_name: project

--- a/src/swift/object_store.go
+++ b/src/swift/object_store.go
@@ -51,7 +51,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 				if config["region"] != "" {
 					region = config["region"]
 				} else {
-					region = "RegionOne"
+					region = ""
 				}
 			}
 		}

--- a/src/swift/object_store_test.go
+++ b/src/swift/object_store_test.go
@@ -13,6 +13,166 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const ID = "0123456789"
+const tokenResp = `{
+    "token": {
+        "audit_ids": ["VcxU2JYqT8OzfUVvrjEITQ", "qNUTIJntTzO1-XUk5STybw"],
+        "catalog": [
+            {
+                "endpoints": [
+                    {
+                        "id": "796186fced4611ee9e2c9cb6d0fbac9d",
+                        "interface": "public",
+                        "region": "RegionOne",
+                        "url": "http://localhost:5000"
+                    },
+                    {
+                        "id": "7c2bb2cced4611ee90c09cb6d0fbac9d",
+                        "interface": "internal",
+                        "region": "RegionOne",
+                        "url": "http://localhost:5000"
+                    },
+                    {
+                        "id": "8080e7b6ed4611ee88be9cb6d0fbac9d",
+                        "interface": "admin",
+                        "region": "RegionOne",
+                        "url": "http://localhost:35357"
+                    }
+                ],
+                "id": "854d03ceed4611ee82b09cb6d0fbac9d",
+                "type": "identity",
+                "name": "keystone"
+            },
+            {
+                "endpoints": [
+                    {
+                        "id": "5fb3e04cc47345079bcccfa5a78d4de6",
+                        "interface": "internal",
+                        "region_id": "myRegion",
+                        "url": "http://localhost/v3/955f0136ed4611ee9f489cb6d0fbac9d",
+                        "region": "myRegion"
+                    },
+                    {
+                        "id": "d48c520ef7b941c692100f24a1437864",
+                        "interface": "public",
+                        "region_id": "myRegion",
+                        "url": "https://localhost/v3/955f0136ed4611ee9f489cb6d0fbac9d",
+                        "region": "myRegion"
+                    },
+                    {
+                        "id": "da15876d31f24af3afc3a69cb918c45f",
+                        "interface": "admin",
+                        "region_id": "myRegion",
+                        "url": "https://localhost/v3/955f0136ed4611ee9f489cb6d0fbac9d",
+                        "region": "myRegion"
+                    }
+                ],
+                "id": "439e9f0d9d224b88a9b01774a9948e5e",
+                "type": "object-store",
+                "name": "swift"
+            },
+            {
+                "endpoints": [
+                    {
+                        "id": "2bed9ab4ed4111eeb4229cb6d0fbac9d",
+                        "interface": "internal",
+                        "region_id": "secondRegion",
+                        "url": "http://localhost2/v3/4c30519aed4111eeab909cb6d0fbac9d",
+                        "region": "secondRegion"
+                    },
+                    {
+                        "id": "3bd7f8caed4111eeb77a9cb6d0fbac9d",
+                        "interface": "public",
+                        "region_id": "secondRegion",
+                        "url": "https://localhost2/v3/4c30519aed4111eeab909cb6d0fbac9d",
+                        "region": "secondRegion"
+                    },
+                    {
+                        "id": "46474c98ed4111eeb2839cb6d0fbac9d",
+                        "interface": "admin",
+                        "region_id": "secondRegion",
+                        "url": "https://localhost2/v3/4c30519aed4111eeab909cb6d0fbac9d",
+                        "region": "secondRegion"
+                    }
+                ],
+                "id": "4c30519aed4111eeab909cb6d0fbac9d",
+                "type": "object-store",
+                "name": "swift"
+            }
+        ],
+        "expires_at": "2025-02-27T18:30:59.999999Z",
+        "is_domain": false,
+        "issued_at": "2025-02-27T16:30:59.999999Z",
+        "methods": [
+            "password"
+        ],
+        "project": {
+            "domain": {
+                "id": "8789d1",
+                "name": "domain"
+            },
+            "id": "04982538-f42b-11ee-a412-9cb6d0fbac9d",
+            "name": "project"
+        },
+        "roles": [
+            {
+                "id": "86e72a",
+                "name": "admin"
+            },
+            {
+                "id": "e4f392",
+                "name": "member"
+            }
+        ],
+        "user": {
+            "domain": {
+                "id": "8789d1",
+                "name": "domain"
+            },
+            "id": "cf78e694-f42a-11ee-bfcc-9cb6d0fbac9d",
+            "name": "user",
+            "password_expires_at": "2026-11-06T15:32:17.000000"
+        }
+    }
+}`
+
+// TestInit performs standard object store initialization
+// which includes creation of auth client, authentication and
+// creation of object storage client.
+// In this test we use simple clouds.yaml and not override
+// any option.
+func TestSimpleObjectStorageInit(t *testing.T) {
+	// Basic structs
+	log := logrus.New()
+	config := map[string]string{
+		"cloud": "myCloud",
+	}
+	os := NewObjectStore(log)
+
+	// Create fake provider client for authentication,
+	// prepare handler for authentication and redirect
+	// provider endpoint to fake client.
+	th.SetupPersistentPortHTTP(t, 32500)
+	defer th.TeardownHTTP()
+	fakeClient.ServiceClient()
+	os.provider = fakeClient.ServiceClient().ProviderClient
+	os.provider.IdentityEndpoint = th.Endpoint()
+
+	th.Mux.HandleFunc("/v3/auth/tokens",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("X-Subject-Token", ID)
+
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, tokenResp)
+		},
+	)
+
+	// Try to Init block storage. This involves authentication.
+	if err := os.Init(config); err != nil {
+		t.Error(err)
+	}
+}
+
 func handleGetObject(t *testing.T, container, object string, data []byte) {
 	th.Mux.HandleFunc(fmt.Sprintf("/%s/%s", container, object),
 		func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
For non-documented reason we switched from having default value for region empty string to value RegionOne (in tag v0.4.0). RegionOne is default region name in Openstack, but this doesn't justify leaving region to default to this value.

Having region as empty string makes the gophercloud library to pick first found region in the catalog. This can cause potential backwards compatibility issues, which are however very unlikely.

Negative impact of having region default to RegionOne is that it makes the plugin to not work in case user relies on region specified in clouds.yaml. This also looks slightly tricky as region in clouds.yaml doesn't neccesarilly mean that that region should be configured in Cinder.

This change and additional test displays the behavior.

Closes https://github.com/Lirt/velero-plugin-for-openstack/issues/109