### PR TITLE
[WIP] Introduce Option to omit VolumeBackup container option

### DIFF
--- a/docs/installation-using-cli.md
+++ b/docs/installation-using-cli.md
@@ -83,6 +83,11 @@ spec:
     # deletes all dependent volume resources (i.e. snapshots) before deleting
     # the clone volume (works only, when a snapshot method is set to clone)
     cascadeDelete: "true"
+    # set to true if OpenStack Cinder is configured to use SWIFT as the backup_driver,
+    # otherwise the default container is being used
+    useSwiftVolumeBackup: "false"
+    # Controls which container gets targeted for backups
+    # containerName: "myContainer"
 ```
 
 For backups of Manila shares create another configuration of `volumesnapshotlocations.velero.io`:

--- a/docs/installation-using-helm.md
+++ b/docs/installation-using-helm.md
@@ -65,6 +65,11 @@ configuration:
       # deletes all dependent volume resources (i.e. snapshots) before deleting
       # the clone volume (works only, when a snapshot method is set to clone)
       cascadeDelete: "true"
+      # set to true if OpenStack Cinder is configured to use SWIFT as the backup_driver,
+      # otherwise the default container is being used
+      useSwiftVolumeBackup: "false"
+      # Controls which container gets targeted for backups
+      # containerName: "myContainer"
   # for Manila shared filesystem storage
   - name: manila
     provider: community.openstack.org/openstack-manila


### PR DESCRIPTION
When using Ceph RBD Backup driver, the container attr set when creating a VolumeSnapshot has to either correspond to the backup rbd pool or be omitted. Many users might not know which rbd_pool that is, so it should just be omitted in that case. Similar to #107 

Since most OS clouds use ceph, it might even make sense to omit it by default and let the use have to explicitly set it. Any thoughts? 