### PR TITLE
Allow backups to be made incrementally

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,17 @@ Cinder backup methods:
 - **Backup** - Create a backup using Cinder backup functionality (known in CLI as `cinder backup create`) - see [docs](https://docs.openstack.org/cinder/latest/admin/volume-backups.html).
 - **Image** - Upload a volume into Glance image service (requires `enable_force_upload` Cinder option enabled on the server side).
 
-> **Note:** For backups, incremental backups are supported. This will however lead to the inability to delete backups in a reverse order, since it is not possible to delete a (older) backup that has dependant (newer) backups. This state is represented in OpenStack through the `has_dependent_backups` property on a backup. 
-Next to that, the first backup of a volume will always be a full backup, since this is needed to create increments on.
-
 Manila backup methods:
 - **Snapshot** - Create a snapshot using Manila.
 - **Clone** - Create a snapshot using Manila, but immediatelly create a volume from this snapshot and afterwards cleanup original snapshot.
+
+#### Incremental backups
+
+For backup method `backups`, incremental backups are supported. This will however lead to the inability to delete backups in a reverse order, since it is not possible to delete a (older) backup that has dependant (newer) backups. 
+
+**Important: TTL is not working correctly with expiration, so set a large value such as (43800h, approx. 5 years)** since TTL inherently use a `First In, First Out` algorithm, where incremental backups should be deleted on a `Last In, First Out` basis.  
+
+Next to that, when incremental backups are enabled, the first backup of a volume will always be a full backup, since this is needed to create increments on.
 
 ### Consistency and Durability
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Manila backup methods:
 
 For backup method `backups`, incremental backups are supported. This will however lead to the inability to delete backups in a reverse order, since it is not possible to delete a (older) backup that has dependant (newer) backups. 
 
-**Important: TTL is not working correctly with expiration, so set a large value such as (43800h, approx. 5 years)** since TTL inherently use a `First In, First Out` algorithm, where incremental backups should be deleted on a `Last In, First Out` basis.  
+**Important: TTL is not working correctly with expiration, so set a large value such as (43800h, approx. 5 years)** since TTL inherently use a `First In, First Out` algorithm, where incremental backups should be deleted on a `Last In, First Out` basis. To cleanup these incremental backups, it's suggested to use the Velero CLI to perform deletion on this `Last In, First Out` basis.
 
 Next to that, when incremental backups are enabled, the first backup of a volume will always be a full backup, since this is needed to create increments on.
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Cinder backup methods:
 - **Backup** - Create a backup using Cinder backup functionality (known in CLI as `cinder backup create`) - see [docs](https://docs.openstack.org/cinder/latest/admin/volume-backups.html).
 - **Image** - Upload a volume into Glance image service (requires `enable_force_upload` Cinder option enabled on the server side).
 
+> **Note:** For backups, incremental backups are supported. This will however lead to the inability to delete backups in a reverse order, since it is not possible to delete a (older) backup that has dependant (newer) backups. This state is represented in OpenStack through the `has_dependent_backups` property on a backup. 
+Next to that, the first backup of a volume will always be a full backup, since this is needed to create increments on.
+
 Manila backup methods:
 - **Snapshot** - Create a snapshot using Manila.
 - **Clone** - Create a snapshot using Manila, but immediatelly create a volume from this snapshot and afterwards cleanup original snapshot.

--- a/docs/installation-using-cli.md
+++ b/docs/installation-using-cli.md
@@ -83,6 +83,8 @@ spec:
     # deletes all dependent volume resources (i.e. snapshots) before deleting
     # the clone volume (works only, when a snapshot method is set to clone)
     cascadeDelete: "true"
+    # backups will be created incrementally (works only when snapshot method is set to backup)
+    incrementalBackup: "true"
 ```
 
 For backups of Manila shares create another configuration of `volumesnapshotlocations.velero.io`:

--- a/docs/installation-using-helm.md
+++ b/docs/installation-using-helm.md
@@ -65,6 +65,8 @@ configuration:
       # deletes all dependent volume resources (i.e. snapshots) before deleting
       # the clone volume (works only, when a snapshot method is set to clone)
       cascadeDelete: "true"
+      # backups will be created incrementally (works only when snapshot method is set to backup)
+      incrementalBackup: "true"
   # for Manila shared filesystem storage
   - name: manila
     provider: community.openstack.org/openstack-manila

--- a/src/cinder/block_store.go
+++ b/src/cinder/block_store.go
@@ -617,9 +617,9 @@ func (b *BlockStore) createBackup(volumeID, volumeAZ string, tags map[string]str
 	}
 
 	var existingBackup *backups.Backup
-	for _, v := range existingBackups {
-		if v.VolumeID == volumeID && utils.SliceContains(backupStatuses, v.Status) {
-			existingBackup = &v
+	for _, b := range existingBackups {
+		if b.VolumeID == volumeID && utils.SliceContains(backupStatuses, b.Status) {
+			existingBackup = &b
 			break
 		}
 	}

--- a/src/cinder/block_store.go
+++ b/src/cinder/block_store.go
@@ -99,6 +99,7 @@ type BlockStore struct {
 	cascadeDelete      bool
 	containerName      string
 	log                logrus.FieldLogger
+	backupIncremental  bool
 }
 
 // NewBlockStore instantiates a Cinder Volume Snapshotter.
@@ -157,6 +158,10 @@ func (b *BlockStore) Init(config map[string]string) error {
 	b.cascadeDelete, err = strconv.ParseBool(utils.GetConf(b.config, "cascadeDelete", "false"))
 	if err != nil {
 		return fmt.Errorf("cannot parse cascadeDelete config variable: %w", err)
+	}
+	b.backupIncremental, err = strconv.ParseBool(utils.GetConf(b.config, "backupIncremental", "false"))
+	if err != nil {
+		return fmt.Errorf("cannot parse backupIncremental config variable: %w", err)
 	}
 
 	// load optional containerName
@@ -321,12 +326,13 @@ func (b *BlockStore) createVolumeFromClone(cloneID, volumeType, volumeAZ string)
 
 func (b *BlockStore) createVolumeFromBackup(backupID, volumeType, volumeAZ string) (string, error) {
 	logWithFields := b.log.WithFields(logrus.Fields{
-		"backupID":      backupID,
-		"volumeType":    volumeType,
-		"volumeAZ":      volumeAZ,
-		"backupTimeout": b.backupTimeout,
-		"volumeTimeout": b.volumeTimeout,
-		"method":        b.config["method"],
+		"backupID":          backupID,
+		"volumeType":        volumeType,
+		"volumeAZ":          volumeAZ,
+		"backupTimeout":     b.backupTimeout,
+		"backupIncremental": b.backupIncremental,
+		"volumeTimeout":     b.volumeTimeout,
+		"method":            b.config["method"],
 	})
 	logWithFields.Info("BlockStore.CreateVolumeFromSnapshot called")
 
@@ -588,12 +594,13 @@ func (b *BlockStore) createClone(volumeID, volumeAZ string, tags map[string]stri
 func (b *BlockStore) createBackup(volumeID, volumeAZ string, tags map[string]string) (string, error) {
 	backupName := fmt.Sprintf("%s.backup.%s", volumeID, strconv.FormatUint(utils.Rand.Uint64(), 10))
 	logWithFields := b.log.WithFields(logrus.Fields{
-		"backupName":    backupName,
-		"volumeID":      volumeID,
-		"volumeAZ":      volumeAZ,
-		"tags":          tags,
-		"backupTimeout": b.backupTimeout,
-		"method":        b.config["method"],
+		"backupName":        backupName,
+		"volumeID":          volumeID,
+		"volumeAZ":          volumeAZ,
+		"tags":              tags,
+		"backupTimeout":     b.backupTimeout,
+		"backupIncremental": b.backupIncremental,
+		"method":            b.config["method"],
 	})
 	logWithFields.Info("BlockStore.CreateSnapshot called")
 
@@ -603,6 +610,12 @@ func (b *BlockStore) createBackup(volumeID, volumeAZ string, tags map[string]str
 		return "", fmt.Errorf("failed to get volume %v from cinder: %w", volumeID, err)
 	}
 
+	existingBackup, _, err := b.findLatestBackup(logWithFields, volumeID)
+	if err != nil {
+		logWithFields.Error("failed to retrieve existing volume backups.")
+		return "", fmt.Errorf("failed to retrieve existing backups %v from cinder: %w", volumeID, err)
+	}
+
 	opts := &backups.CreateOpts{
 		Name:        backupName,
 		VolumeID:    volumeID,
@@ -610,11 +623,18 @@ func (b *BlockStore) createBackup(volumeID, volumeAZ string, tags map[string]str
 		Container:   backupName,
 		Metadata:    utils.Merge(originVolume.Metadata, tags),
 		Force:       true,
+		Incremental: b.backupIncremental,
 	}
 
 	// Override container if one was passed by the user
 	if b.containerName != "" {
 		opts.Container = b.containerName
+	}
+
+	// Disable incremental backup for volume where no backup exists yet.
+	if b.backupIncremental && existingBackup == nil {
+		logWithFields.Infof("No backup exists yet for volume %s, will first run a full backup.", volumeID)
+		opts.Incremental = false
 	}
 
 	backup, err := backups.Create(b.client, opts).Extract()
@@ -1092,4 +1112,25 @@ func expandVolumeProperties(log logrus.FieldLogger, volume *volumes.Volume) imag
 		})
 	}
 	return imgAttrUpdateOpts
+}
+
+func (b *BlockStore) findLatestBackup(logWithFields *logrus.Entry, volumeID string) (*backups.Backup, []backups.Backup, error) {
+	// use detail and a non-volumeid search to allow usage of later microversions
+	pages, err := backups.List(b.client, nil).AllPages()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list backups: %w", err)
+	}
+	allBackups, err := backups.ExtractBackups(pages)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to extract backups: %w", err)
+	}
+
+	for _, v := range allBackups {
+		if v.VolumeID == volumeID && utils.SliceContains(backupStatuses, v.Status) {
+			return &v, allBackups, nil
+		}
+	}
+
+	logWithFields.Infof("not able to find an active backup for volume: %q", volumeID)
+	return nil, allBackups, nil
 }

--- a/src/cinder/block_store_test.go
+++ b/src/cinder/block_store_test.go
@@ -343,7 +343,7 @@ func TestGetVolumeBackups(t *testing.T) {
 
 func TestCreateBackup(t *testing.T) {
 	th.SetupHTTP()
-	defer th.TeardownHTTP() 
+	defer th.TeardownHTTP()
 
 	backupID := "d32019d3-bc6e-4319-9c1d-6722fc136a22"
 	var createRequest *CreateIncrementalBackupRequest
@@ -380,10 +380,18 @@ func TestCreateBackup(t *testing.T) {
 
 	for _, tt := range tests {
 		handleGetVolume(t, tt.volumeID)
-		store.createBackup(tt.volumeID, "default", map[string]string{})
+		createdBackupID, err := store.createBackup(tt.volumeID, "default", map[string]string{})
 
 		if createRequest.Backup.Incremental != tt.expectedIncrementalValue {
 			t.Errorf("expected incremental backup to be set to %v, got %v", tt.expectedIncrementalValue, createRequest.Backup.Incremental)
+		}
+
+		if createdBackupID != backupID {
+			t.Errorf("expected created backup ID to be %v, got %v", backupID, createdBackupID)
+		}
+
+		if !assert.Nil(t, err) {
+			t.FailNow()
 		}
 	}
 }


### PR DESCRIPTION
This implements the incremental backup functionality as described in the OpenStack [docs](https://docs.openstack.org/cinder/latest/admin/volume-backups.html)

Added some unit tests for block storage backup creation and the different incremental backup scenario's.